### PR TITLE
System/nanoTime instead of System/currentTimeMillis

### DIFF
--- a/src/cognician/dogstatsd.clj
+++ b/src/cognician/dogstatsd.clj
@@ -116,9 +116,9 @@
 
 
 (defmacro measure! [metric opts & body]
-  `(let [t0#  (System/currentTimeMillis)
+  `(let [t0#  (System/nanoTime)
          res# (do ~@body)]
-     (histogram! ~metric (- (System/currentTimeMillis) t0#) ~opts)
+     (histogram! ~metric (/ (- (System/nanoTime) t0#) 1000000.0) ~opts)
      res#))
 
 


### PR DESCRIPTION
The precision is slightly improved, but it comes with a tradeoff that I'm not sure is worth it.

`System/nanoTime` is more accurate than `currentTimeMillis`, but it is definitely more expensive. For some instances, I can see the added precision being valuable (if you wanted to detect really small amounts of jitter in a datadog monitor for instance), but `currentTimeMillis` might be the better default option.
